### PR TITLE
Allow HTTP transport to be configured

### DIFF
--- a/fhclient/main.go
+++ b/fhclient/main.go
@@ -3,15 +3,17 @@ package fhclient
 import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"net/http"
 
 	client "github.com/firehydrant/api-client-go/client"
 	transport "github.com/go-openapi/runtime/client"
 )
 
 type Config struct {
-	ApiHost string
-	ApiKey  string
-	Debug   bool
+	ApiHost   string
+	ApiKey    string
+	Debug     bool
+	Transport http.RoundTripper
 }
 
 type ApiClient struct {
@@ -25,6 +27,9 @@ func NewApiClient(c Config) ApiClient {
 
 	fhApiClient.transport = transport.New(c.ApiHost, "", []string{"https"})
 	fhApiClient.transport.Debug = c.Debug
+	if c.Transport != nil {
+		fhApiClient.transport.Transport = c.Transport
+	}
 
 	fhApiClient.Client = client.New(fhApiClient.transport, strfmt.Default)
 	fhApiClient.Auth = transport.BearerToken(c.ApiKey)


### PR DESCRIPTION
In order to setup telemetry, we need to be able to configure the HTTP transport that's used by the client.  This PR exposes this configuration option, which allows for something like this following:

```go
package main

import (
	"net/http"

	"github.com/firehydrant/api-client-go/fhclient"
	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
)

func main() {
	c := fhclient.NewApiClient(fhclient.Config{
		ApiHost:   "api.firehydrant.io",
		ApiKey:    "fhb-triforce",
		Transport: otelhttp.NewTransport(http.DefaultTransport),
	})
}
```

Once the client is configured with [otelhttp](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/net/http/otelhttp), requests should be automatically instrumented for OpenTelemetry.