### PR TITLE
CI: don't push fail when there are no changes

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -50,8 +50,11 @@ jobs:
           git checkout -b "${branch}"
           git config --global user.email "44629778+firehydrant-ops@users.noreply.github.com"
           git config --global user.name "FireHydrant Bot"
+
           git add .
-          git commit -m "Regenerate Swagger code ${api_server_revision}"
+          # If there are no changes, exit 0 and don't push
+          git commit -m "Regenerate Swagger code ${api_server_revision}" || exit 0
+
           git push -u origin "${branch}"
           gh pr create \
             --title "Regenerate Swagger code \`${api_server_revision}\`" \


### PR DESCRIPTION
Currently, if there are no changes to generated code, the action will fail, which isn't necessarily accurate.

<img width="912" alt="image" src="https://github.com/firehydrant/api-client-go/assets/14004487/9959c6ac-3218-4a90-b2a2-d15c75a1f5c3">


With this changeset, we will instead `exit 0` when there are no changes.

<img width="909" alt="image" src="https://github.com/firehydrant/api-client-go/assets/14004487/868c2fa2-20ff-4647-a53b-b7eba4d8f797">
