### PR TITLE
ci: minimize schedule, safer push

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -47,6 +47,9 @@ jobs:
           branch="swagger/${api_server_revision}"
 
           set -x
+          # If remote branch exists, just terminate early.
+          git fetch origin "${branch}" && exit 0 || true
+
           git checkout -b "${branch}"
           git config --global user.email "44629778+firehydrant-ops@users.noreply.github.com"
           git config --global user.name "FireHydrant Bot"

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -3,7 +3,7 @@ name: Sync
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1-4'
 
 permissions:
   contents: write


### PR DESCRIPTION
This changeset moves the execution of client auto-generator from "everyday" to "every Monday-Thursday". Additionally, don't error out if remote branch already exists — just terminate early.