### PR TITLE
Readme message directing to new repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,3 @@
 # FireHydrant API Client Library
 
-This is auto-generated from the swagger doc available at https://api.firehydrant.io/v1/swagger_doc
-
-To generate the client, run `make generate`
+This is archived in favor of https://github.com/firehydrant/firehydrant-go-sdk.  Go there for the most recently updated client.


### PR DESCRIPTION
Before archiving this repo, we should redirect so no one else is confused (like I was) about which is the updated client.